### PR TITLE
Fix pytest configuration errors

### DIFF
--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -1,0 +1,1 @@
+"""Top-level package for the Django project."""

--- a/backend/backend/__init__.py
+++ b/backend/backend/__init__.py
@@ -1,0 +1,21 @@
+"""Django project package initialization."""
+
+import sys
+from importlib import util
+from pathlib import Path
+
+# Ensure the Django app living at ``backend/inventory`` can be imported via both
+# ``backend.inventory`` and ``inventory`` regardless of the current working
+# directory. This mirrors the project layout expected by the tests.
+if 'backend.inventory' not in sys.modules:
+    inventory_path = Path(__file__).resolve().parent.parent / 'inventory'
+    spec = util.spec_from_file_location(
+        'backend.inventory',
+        inventory_path / '__init__.py',
+        submodule_search_locations=[str(inventory_path)],
+    )
+    module = util.module_from_spec(spec)
+    sys.modules['backend.inventory'] = module
+    sys.modules.setdefault('inventory', module)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)

--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -12,7 +12,8 @@ https://docs.djangoproject.com/en/5.1/ref/settings/
 
 from pathlib import Path
 import environ
-# import os
+
+env = environ.Env()
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
@@ -39,7 +40,7 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
-    'inventory'
+    'inventory',
 ]
 
 MIDDLEWARE = [

--- a/backend/inventory/__init__.py
+++ b/backend/inventory/__init__.py
@@ -1,0 +1,1 @@
+"""Inventory application package."""

--- a/backend/settings.py
+++ b/backend/settings.py
@@ -1,0 +1,3 @@
+"""Compatibility shim for tools importing ``backend.settings`` from the repository root."""
+
+from .backend.settings import *  # noqa: F401,F403

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,5 @@
+"""Pytest configuration module.
+
+At the moment this file does not need any runtime hooks, but it stays in place
+in case future tests require project-specific fixtures.
+"""


### PR DESCRIPTION
## Summary
- instantiate the environment loader in the Django settings module so pytest-django can read database variables
- expose the backend settings module and inventory app when pytest is executed from the repository root
- add a lightweight conftest module placeholder for future pytest hooks

## Testing
- pytest *(fails: OperationalError: connection failed: connection to server at "127.0.0.1", port 5432 failed)*

------
https://chatgpt.com/codex/tasks/task_e_68ca359f10bc832ab1c2cc74fed007ac