### PR TITLE
Configure CI workflow with PostgreSQL service

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -14,32 +14,70 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    env:
+      DB_NAME: frigiradium
+      DB_USER: frigiradium
+      DB_PASSWORD: frigiradium
+      DB_HOST: 127.0.0.1
+      DB_PORT: "5432"
+
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_DB: ${{ env.DB_NAME }}
+          POSTGRES_USER: ${{ env.DB_USER }}
+          POSTGRES_PASSWORD: ${{ env.DB_PASSWORD }}
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd="pg_isready -U $POSTGRES_USER"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=5
+
     steps:
-    - uses: actions/checkout@v4
-    - name: Set up Python 3.10
-      uses: actions/setup-python@v6
-      with:
-        python-version: "3.10"
-        cache: 'pip'
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install flake8 pytest
-        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-    - name: Lint with flake8
-      run: |
-        # stop the build if there are Python syntax errors or undefined names
-        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-    - name: Run pytest and capture JUnit XML
-      run: |
-        mkdir -p test-results
-        pytest --junitxml=test-results/pytest.xml
-    - name: Upload pytest test results
-      if: always()
-      uses: actions/upload-artifact@v4
-      with:
-        name: pytest-results
-        path: test-results/pytest.xml
-        retention-days: 1
+      - uses: actions/checkout@v4
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.10"
+          cache: 'pip'
+      - name: Install PostgreSQL client
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y postgresql-client
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install flake8 pytest
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+      - name: Lint with flake8
+        run: |
+          # stop the build if there are Python syntax errors or undefined names
+          flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+          # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+          flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+      - name: Wait for PostgreSQL to be ready
+        run: |
+          for attempt in {1..10}; do
+            if pg_isready -h "$DB_HOST" -p "$DB_PORT" -U "$DB_USER"; then
+              echo "PostgreSQL is ready."
+              exit 0
+            fi
+            echo "Waiting for PostgreSQL (attempt ${attempt}/10)"
+            sleep 3
+          done
+          echo "PostgreSQL did not become ready in time." >&2
+          exit 1
+      - name: Run pytest and capture JUnit XML
+        run: |
+          mkdir -p test-results
+          pytest --junitxml=test-results/pytest.xml
+      - name: Upload pytest test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: pytest-results
+          path: test-results/pytest.xml
+          retention-days: 1


### PR DESCRIPTION
## Summary
- configure the GitHub Actions workflow to expose PostgreSQL 16 with matching environment variables and health checks
- install the PostgreSQL client and add an explicit readiness loop so pytest waits for the database

## Testing
- Not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68da295aafa0832a966d2e10eea1d2f1